### PR TITLE
fixed variable name mismatch

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -139,8 +139,8 @@ gcc_version_ok() {
 
 	if [[ $GCC_MAJOR -lt 4
 		|| ( $GCC_MAJOR -eq 4 && $GCC_MINOR -lt 7 )
-		|| ( $GCC_MAJOR -eq 4 && $GCC_MINOR -eq 7 && $GCC_THIRD -lt 3 )
-		|| ( $GCC_MAJOR -eq 4 && $GCC_MINOR -eq 8 && $GCC_THIRD -eq 0 )
+		|| ( $GCC_MAJOR -eq 4 && $GCC_MINOR -eq 7 && $GCC_PATCH -lt 3 )
+		|| ( $GCC_MAJOR -eq 4 && $GCC_MINOR -eq 8 && $GCC_PATCH -eq 0 )
 		]] ; then
 		echo "gcc version required >= 4.7.3, != 4.8.0, >= 4.8.1, got $GCC_VERSION"
 		return 1


### PR DESCRIPTION
There is a variable name mismatch in build.sh's `gcc_version_ok()`, which prevents proper version checking for GCC.

There is another issue with GCC's `-dumpversion` option: In my version of GCC (4.8.5) it only returns "4.8", missing the patch version. I can fix this in build.sh with
~~~
   GCC_VERSION=`gcc --version | head -1 | cut -d" " -f"4"`
~~~

but as I don't know how other GCC versions might behave, I left it as it was.